### PR TITLE
Remove unneeded escaping in here-doc

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -41,11 +41,11 @@ if ! command -v pyenv 1>/dev/null 2>&1; then
   cat <<EOS
 Seems you still have not added 'pyenv' to the load path:
 
-export PYENV_ROOT=\"\${HOME}/.pyenv\"
+export PYENV_ROOT="\${HOME}/.pyenv"
 
-if [ -d \"\${PYENV_ROOT}\" ]; then
-  export PATH=\"\${PYENV_ROOT}/bin:\${PATH}\"
-  eval \"\$(pyenv init -)\"
+if [ -d "\${PYENV_ROOT}" ]; then
+  export PATH="\${PYENV_ROOT}/bin:\${PATH}"
+  eval "\$(pyenv init -)"
 fi
 EOS
 fi


### PR DESCRIPTION
There is no need to escape double-quotes in here-doc strings.
The current output contains a lot of \" that have to be converted to " manually after coping the bash code snippet in your starting scripts.
