### PR TITLE
Added missing quote to instructions after install

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -72,7 +72,7 @@ if ! command -v pyenv 1>/dev/null; then
       echo 'status --is-interactive; and . (pyenv init -|psub)'
       ;;
     * )
-      echo "export PATH=\"\$HOME/.pyenv/bin:\$PATH"
+      echo "export PATH=\"\$HOME/.pyenv/bin:\$PATH\""
       echo "eval \"\$(pyenv init -)\""
       ;;
     esac


### PR DESCRIPTION
Hello again, just another tiny fix which I noticed when installing pyenv today :smile: 

Cheers
Fotis
