### PR TITLE
Fix repo URLs to point to `pyenv` organisation

### DIFF
--- a/bin/download-pyenv-package.sh
+++ b/bin/download-pyenv-package.sh
@@ -17,12 +17,12 @@ else
 fi
 
 # checkout to temporary directory.
-checkout "${GITHUB}/yyuu/pyenv.git"            "$TMP_DIR"
-checkout "${GITHUB}/yyuu/pyenv-doctor.git"     "$TMP_DIR"
-checkout "${GITHUB}/yyuu/pyenv-installer.git"  "$TMP_DIR"
-checkout "${GITHUB}/yyuu/pyenv-update.git"     "$TMP_DIR"
-checkout "${GITHUB}/yyuu/pyenv-virtualenv.git" "$TMP_DIR"
-checkout "${GITHUB}/yyuu/pyenv-which-ext.git"  "$TMP_DIR"
+checkout "${GITHUB}/pyenv/pyenv.git"            "$TMP_DIR"
+checkout "${GITHUB}/pyenv/pyenv-doctor.git"     "$TMP_DIR"
+checkout "${GITHUB}/pyenv/pyenv-installer.git"  "$TMP_DIR"
+checkout "${GITHUB}/pyenv/pyenv-update.git"     "$TMP_DIR"
+checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "$TMP_DIR"
+checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "$TMP_DIR"
 
 # create archive.
 tar -zcf "$PYENV_PACKAGE_ARCHIVE" -C "$TMP_DIR" .

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -36,12 +36,12 @@ else
   GITHUB="https://github.com"
 fi
 
-checkout "${GITHUB}/yyuu/pyenv.git"            "${PYENV_ROOT}"
-checkout "${GITHUB}/yyuu/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"
-checkout "${GITHUB}/yyuu/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"
-checkout "${GITHUB}/yyuu/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"
-checkout "${GITHUB}/yyuu/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"
-checkout "${GITHUB}/yyuu/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"
+checkout "${GITHUB}/pyenv/pyenv.git"            "${PYENV_ROOT}"
+checkout "${GITHUB}/pyenv/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"
+checkout "${GITHUB}/pyenv/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"
+checkout "${GITHUB}/pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"
+checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"
+checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"
 
 if ! command -v pyenv 1>/dev/null; then
   { echo


### PR DESCRIPTION
Fix repository URLs to point to the `pyenv` organisation on GitHub, rather than the individual account `yyuu`. Hopefully this may help to future-proof pyenv installations made with pyenv-installer.