### PR TITLE
fix error about wrong command

### DIFF
--- a/bin/download-pyenv-package.sh
+++ b/bin/download-pyenv-package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 checkout() {
-  [ -d "$2" ] && $(cd "$2"; git clone "$1")
+  [ -d "$2" ] && (cd "$2"; git clone "$1")
 }
 
 if [ -z "$PYENV_PACKAGE_ARCHIVE" ]; then


### PR DESCRIPTION
+ Cloning into ''\''pyenv'\''...'
download-pyenv-package.sh: line 4: Cloning: command not found