### PR TITLE
fix: suggests removal of .pyenv folder on reinstallation

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -89,4 +89,11 @@ if ! command -v pyenv 1>/dev/null; then
       ;;
     esac
   } >&2
+elif [ -d "${PYENV_ROOT}" ]; then
+  { echo
+    colorize 1 "WARNING"
+    echo ": Kindly remove '.pyenv' from ${HOME} to proceed with installation."
+    echo
+  } >&2
+    exit 1
 fi

--- a/bin/pyenv-offline-installer
+++ b/bin/pyenv-offline-installer
@@ -100,4 +100,11 @@ if ! command -v pyenv 1>/dev/null; then
       ;;
     esac
   } >&2
+elif [ -d "${PYENV_ROOT}" ]; then
+  { echo
+    colorize 1 "WARNING"
+    echo ": Kindly remove '.pyenv' from ${HOME} to proceed with installation."
+    echo
+  } >&2
+    exit 1
 fi


### PR DESCRIPTION
Fixes #75 

- Suggest user to remove `.pyenv` for reinstallation/updation
- Won't work if previous installation is incomplete.