### PR TITLE
Explicitly set .pyenv PATH

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ and remove these three lines from ``.bashrc``:
 
 .. code:: bash
 
-    export PATH="~/.pyenv/bin:$PATH"
+    export PATH="$HOME/.pyenv/bin:$PATH"
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
 


### PR DESCRIPTION
This is breaking some customers, who just copy paste these lines into their `*rc` file

See https://github.com/pyenv/pyenv-virtualenv/issues/233#issuecomment-490677591