### PR TITLE
Add ability to install a specific version of pyenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,7 @@ Once prerequisites have been installed correctly:
 
 Install:
 ~~~~
-Set ``PYENV_GIT_TAG`` to install a specific tagged version of pyenv (e.g. ``export PYENV_GIT_TAG=v2.2.5``).
-Otherwise the tip from master will be used.
+If you wish to install a specific release of Pyenv rather than the latest head, set the ``PYENV_GIT_TAG`` environment variable (e.g. ``export PYENV_GIT_TAG=v2.2.5``).
 
 .. code:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ Once prerequisites have been installed correctly:
 
 Install:
 ~~~~
+Set ``PYENV_GIT_TAG`` to install a specific tagged version of pyenv (e.g. ``export PYENV_GIT_TAG=v2.2.5``).
+Otherwise the tip from master will be used.
+
 .. code:: bash
 
     curl https://pyenv.run | bash

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -29,7 +29,7 @@ failed_checkout() {
 }
 
 checkout() {
-  [ -d "$2" ] || git clone --depth 1 "$1" "$2" || failed_checkout "$1"
+  [ -d "$2" ] || git -c advice.detachedHead=0 clone --branch "$3" --depth 1 "$1" "$2" || failed_checkout "$1"
 }
 
 if ! command -v git 1>/dev/null 2>&1; then
@@ -43,12 +43,12 @@ else
   GITHUB="https://github.com"
 fi
 
-checkout "${GITHUB}/pyenv/pyenv.git"            "${PYENV_ROOT}"
-checkout "${GITHUB}/pyenv/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"
-checkout "${GITHUB}/pyenv/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"
-checkout "${GITHUB}/pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"
-checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"
-checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"
+checkout "${GITHUB}/pyenv/pyenv.git"            "${PYENV_ROOT}"                           "${PYENV_GIT_TAG:-master}"
+checkout "${GITHUB}/pyenv/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"      "master"
+checkout "${GITHUB}/pyenv/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"   "master"
+checkout "${GITHUB}/pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"      "master"
+checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"  "master"
+checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"   "master"
 
 if ! command -v pyenv 1>/dev/null; then
   { echo


### PR DESCRIPTION
This pull request is in attempt to have changes made to allow a user to specify a specific version of pyenv to install. 

It appears I am not the only one who wants to be able to install a specific version of pyenv. See: #120
- #38 could possibly be of the same request but I am uncertain if the individual was talking about this repo or any of the other adjacent repos used.
- Fixes #120 

The [pyenv-doctor](https://github.com/pyenv/pyenv-doctor), [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv), and [pyenv-which-ext](https://github.com/pyenv/pyenv-which-ext)  plugins also have tags in their repos, however none of those tags are current (e.g. they are a few years old). So I do not imagine anyone wanting to use a specific version of those plugins, hence they will remain to use the default branch (in this case, master).

The following option and option value were appended to git because after running git clone, git will "advised" the current user that using a tagged version will cause the repo to have a detached head. 
```git -c advice.detachedHead=0 ...```

The advisement looks like this:
```
Cloning into '/home/conner/git/pyenv-installer/bin/.pyenv'...
remote: Enumerating objects: 842, done.
remote: Counting objects: 100% (842/842), done.
remote: Compressing objects: 100% (428/428), done.
remote: Total 842 (delta 476), reused 548 (delta 311), pack-reused 0
Receiving objects: 100% (842/842), 438.13 KiB | 7.18 MiB/s, done.
Resolving deltas: 100% (476/476), done.
Note: switching to '066c05336f3ac6c17e7e696abf0d7de1c3d61ae8'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false
```
This is not the prettiest thing to look at. The appended option/option value will temporarily turn this advice off. 

I did testing locally on my Linux machine. Maintainers, is there any further testing you wish me todo? Should the README.rst be updated?