### PR TITLE
Replace git protocol with ssh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*pyenv-package.tar.gz
+
 *.swo
 *.swp
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Restart your shell so the path changes take effect:
 
 You can now begin using pyenv.
 
-If you need, ``export USE_GIT_URI`` to use ``git://`` instead of ``https://`` for git clone.
+If you need, ``export USE_SSH_URL`` to use ``git@github.com``(SSH pseudo-URL) instead of ``https://`` for git clone.(Need to install `ssh` first)
 
 Update:
 ~~~~

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Restart your shell so the path changes take effect:
 
 You can now begin using pyenv.
 
-If you need, ``export USE_SSH`` to use ``git@github.com``(SSH pseudo-URL) instead of ``https://`` for git clone.(Need to install `ssh` first)
+If you need, ``export USE_SSH`` to use ``git@github.com``(SSH pseudo-URL) instead of ``https://`` for git clone. (Need to have `ssh` installled.)
 
 Update:
 ~~~~

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Restart your shell so the path changes take effect:
 
 You can now begin using pyenv.
 
-If you need, ``export USE_SSH_URL`` to use ``git@github.com``(SSH pseudo-URL) instead of ``https://`` for git clone.(Need to install `ssh` first)
+If you need, ``export USE_SSH`` to use ``git@github.com``(SSH pseudo-URL) instead of ``https://`` for git clone.(Need to install `ssh` first)
 
 Update:
 ~~~~

--- a/bin/download-pyenv-package.sh
+++ b/bin/download-pyenv-package.sh
@@ -10,30 +10,30 @@ fi
 
 TMP_DIR=$(mktemp -d)
 
-# Check ssh authentication if USE_SSH_URL is present
-if [ -n "${USE_SSH_URL}" ]; then
+# Check ssh authentication if USE_SSH is present
+if [ -n "${USE_SSH}" ]; then
   if ! command -v ssh 1>/dev/null 2>&1; then
     echo "pyenv: configuration USE_SSH found but ssh is not installed, can't continue." >&2
     exit 1
   fi
 
+  # `ssh -T git@github.com' returns 1 on success
+  # See https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection
   ssh -T git@github.com 1>/dev/null 2>&1 || EXIT_CODE=$?
   if [[ ${EXIT_CODE} != 1 ]]; then
-    {
       echo "pyenv: github ssh authentication failed."
       echo
-      echo "Considering generate a ssh key using ssh-keygen and register it first."
+      echo "In order to use the ssh connection option, you need to have an ssh key set up."
+      echo "Please generate an ssh key by using ssh-keygen, or follow the instructions at the following URL for more information:"
       echo
-      echo "See the link below for more information:"
+      echo "> https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-ssh-access"
       echo
-      echo "  https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-ssh-access"
-      echo
-    } >&2
+      echo "Once you have an ssh key set up, try running the command again."
     exit 1
   fi
 fi
 
-if [ -n "${USE_SSH_URL}" ]; then
+if [ -n "${USE_SSH}" ]; then
   GITHUB="git@github.com:"
 else
   GITHUB="https://github.com/"

--- a/bin/download-pyenv-package.sh
+++ b/bin/download-pyenv-package.sh
@@ -10,19 +10,42 @@ fi
 
 TMP_DIR=$(mktemp -d)
 
-if [ -n "${USE_HTTPS}" ]; then
-  GITHUB="https://github.com"
+# Check ssh authentication if USE_SSH_URL is present
+if [ -n "${USE_SSH_URL}" ]; then
+  if ! command -v ssh 1>/dev/null 2>&1; then
+    echo "pyenv: configuration USE_SSH found but ssh is not installed, can't continue." >&2
+    exit 1
+  fi
+
+  ssh -T git@github.com 1>/dev/null 2>&1 || EXIT_CODE=$?
+  if [[ ${EXIT_CODE} != 1 ]]; then
+    {
+      echo "pyenv: github ssh authentication failed."
+      echo
+      echo "Considering generate a ssh key using ssh-keygen and register it first."
+      echo
+      echo "See the link below for more information:"
+      echo
+      echo "  https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-ssh-access"
+      echo
+    } >&2
+    exit 1
+  fi
+fi
+
+if [ -n "${USE_SSH_URL}" ]; then
+  GITHUB="git@github.com:"
 else
-  GITHUB="git://github.com"
+  GITHUB="https://github.com/"
 fi
 
 # checkout to temporary directory.
-checkout "${GITHUB}/pyenv/pyenv.git"            "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-doctor.git"     "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-installer.git"  "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-update.git"     "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv.git"            "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-doctor.git"     "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-installer.git"  "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-update.git"     "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-virtualenv.git" "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-which-ext.git"  "$TMP_DIR"
 
 # create archive.
 tar -zcf "$PYENV_PACKAGE_ARCHIVE" -C "$TMP_DIR" .

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -37,30 +37,30 @@ if ! command -v git 1>/dev/null 2>&1; then
   exit 1
 fi
 
-# Check ssh authentication if USE_SSH_URL is present
-if [ -n "${USE_SSH_URL}" ]; then
+# Check ssh authentication if USE_SSH is present
+if [ -n "${USE_SSH}" ]; then
   if ! command -v ssh 1>/dev/null 2>&1; then
     echo "pyenv: configuration USE_SSH found but ssh is not installed, can't continue." >&2
     exit 1
   fi
 
+  # `ssh -T git@github.com' returns 1 on success
+  # See https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection
   ssh -T git@github.com 1>/dev/null 2>&1 || EXIT_CODE=$?
   if [[ ${EXIT_CODE} != 1 ]]; then
-    {
       echo "pyenv: github ssh authentication failed."
       echo
-      echo "Considering generate a ssh key using ssh-keygen and register it first."
+      echo "In order to use the ssh connection option, you need to have an ssh key set up."
+      echo "Please generate an ssh key by using ssh-keygen, or follow the instructions at the following URL for more information:"
       echo
-      echo "See the link below for more information:"
+      echo "> https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-ssh-access"
       echo
-      echo "  https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-ssh-access"
-      echo
-    } >&2
+      echo "Once you have an ssh key set up, try running the command again."
     exit 1
   fi
 fi
 
-if [ -n "${USE_SSH_URL}"]; then
+if [ -n "${USE_SSH}"]; then
   GITHUB="git@github.com:"
 else
   GITHUB="https://github.com/"

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -37,18 +37,41 @@ if ! command -v git 1>/dev/null 2>&1; then
   exit 1
 fi
 
-if [ -n "${USE_GIT_URI}" ]; then
-  GITHUB="git://github.com"
-else
-  GITHUB="https://github.com"
+# Check ssh authentication if USE_SSH_URL is present
+if [ -n "${USE_SSH_URL}" ]; then
+  if ! command -v ssh 1>/dev/null 2>&1; then
+    echo "pyenv: configuration USE_SSH found but ssh is not installed, can't continue." >&2
+    exit 1
+  fi
+
+  ssh -T git@github.com 1>/dev/null 2>&1 || EXIT_CODE=$?
+  if [[ ${EXIT_CODE} != 1 ]]; then
+    {
+      echo "pyenv: github ssh authentication failed."
+      echo
+      echo "Considering generate a ssh key using ssh-keygen and register it first."
+      echo
+      echo "See the link below for more information:"
+      echo
+      echo "  https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-ssh-access"
+      echo
+    } >&2
+    exit 1
+  fi
 fi
 
-checkout "${GITHUB}/pyenv/pyenv.git"            "${PYENV_ROOT}"                           "${PYENV_GIT_TAG:-master}"
-checkout "${GITHUB}/pyenv/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"      "master"
-checkout "${GITHUB}/pyenv/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"   "master"
-checkout "${GITHUB}/pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"      "master"
-checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"  "master"
-checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"   "master"
+if [ -n "${USE_SSH_URL}"]; then
+  GITHUB="git@github.com:"
+else
+  GITHUB="https://github.com/"
+fi
+
+checkout "${GITHUB}pyenv/pyenv.git"            "${PYENV_ROOT}"                           "${PYENV_GIT_TAG:-master}"
+checkout "${GITHUB}pyenv/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"      "master"
+checkout "${GITHUB}pyenv/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"   "master"
+checkout "${GITHUB}pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"      "master"
+checkout "${GITHUB}pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"  "master"
+checkout "${GITHUB}pyenv/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"   "master"
 
 if ! command -v pyenv 1>/dev/null; then
   { echo


### PR DESCRIPTION
According to [Github's blog post][post], they had disabled unencrypted Git protocol since March 15, 2022.
This PR converts the old git protocol to the ssh one.

References:
+ https://github.blog/2021-09-01-improving-git-protocol-security-github/
+ https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting
+ https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories#changing-a-remote-repositorys-url

[post]: https://github.blog/2021-09-01-improving-git-protocol-security-github/