### PR TITLE
fix: Offline installer invalid git URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*pyenv-package.tar.gz
+
 *.swo
 *.swp
 

--- a/bin/download-pyenv-package.sh
+++ b/bin/download-pyenv-package.sh
@@ -11,18 +11,18 @@ fi
 TMP_DIR=$(mktemp -d)
 
 if [ -n "${USE_HTTPS}" ]; then
-  GITHUB="https://github.com"
+  GITHUB="https://github.com/"
 else
-  GITHUB="git://github.com"
+  GITHUB="git@github.com:"
 fi
 
 # checkout to temporary directory.
-checkout "${GITHUB}/pyenv/pyenv.git"            "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-doctor.git"     "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-installer.git"  "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-update.git"     "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "$TMP_DIR"
-checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv.git"            "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-doctor.git"     "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-installer.git"  "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-update.git"     "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-virtualenv.git" "$TMP_DIR"
+checkout "${GITHUB}pyenv/pyenv-which-ext.git"  "$TMP_DIR"
 
 # create archive.
 tar -zcf "$PYENV_PACKAGE_ARCHIVE" -C "$TMP_DIR" .


### PR DESCRIPTION
# Info

Fixes https://github.com/pyenv/pyenv-installer/issues/139.


### Before 

```
./download-pyenv-package.sh
Cloning into 'pyenv'...
fatal: unable to connect to github.com:
github.com[0: 140.82.112.4]: errno=Operation timed out

Cloning into 'pyenv-doctor'...
fatal: unable to connect to github.com:
github.com[0: 140.82.112.4]: errno=Operation timed out
...
```

### After

```
./download-pyenv-package.sh
Cloning into 'pyenv'...
remote: Enumerating objects: 22220, done.
remote: Counting objects: 100% (288/288), done.
remote: Compressing objects: 100% (161/161), done.
remote: Total 22220 (delta 152), reused 237 (delta 111), pack-reused 21932
Receiving objects: 100% (22220/22220), 4.49 MiB | 9.72 MiB/s, done.
Resolving deltas: 100% (15014/15014), done.
...
```