### PR TITLE
Fix faulty condition on variable length

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -60,7 +60,7 @@ if [ -n "${USE_SSH}" ]; then
   fi
 fi
 
-if [ -n "${USE_SSH}"]; then
+if [ -n "${USE_SSH}" ]; then
   GITHUB="git@github.com:"
 else
   GITHUB="https://github.com/"


### PR DESCRIPTION
````
bash-5.2# curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash -x
+ bash -x
+ curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer
+ set -e
+ '[' -n '' ']'
+ '[' -z '' ']'
+ export PYENV_ROOT=/root/.pyenv
+ PYENV_ROOT=/root/.pyenv
+ '[' -d /root/.pyenv ']'
+ command -v git
+ '[' -n '' ']'
+ '[' -n ']'
+ GITHUB=git@github.com:
+ checkout git@github.com:pyenv/pyenv.git /root/.pyenv master
+ '[' -d /root/.pyenv ']'
+ git -c advice.detachedHead=0 clone --branch master --depth 1 git@github.com:pyenv/pyenv.git /root/.pyenv
Cloning into '/root/.pyenv'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
+ failed_checkout git@github.com:pyenv/pyenv.git
+ echo 'Failed to git clone git@github.com:pyenv/pyenv.git'
Failed to git clone git@github.com:pyenv/pyenv.git
+ exit -1
```