### PR TITLE
chore: remove which-ext

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -71,7 +71,6 @@ checkout "${GITHUB}pyenv/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doct
 checkout "${GITHUB}pyenv/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"   "master"
 checkout "${GITHUB}pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"      "master"
 checkout "${GITHUB}pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"  "master"
-checkout "${GITHUB}pyenv/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"   "master"
 
 if ! command -v pyenv 1>/dev/null; then
   { echo

--- a/bin/pyenv-offline-installer
+++ b/bin/pyenv-offline-installer
@@ -56,7 +56,6 @@ conditional_mv "$TMP_DIR/pyenv-doctor"     "${PYENV_ROOT}/plugins/pyenv-doctor"
 conditional_mv "$TMP_DIR/pyenv-installer"  "${PYENV_ROOT}/plugins/pyenv-installer"
 conditional_mv "$TMP_DIR/pyenv-update"     "${PYENV_ROOT}/plugins/pyenv-update"
 conditional_mv "$TMP_DIR/pyenv-virtualenv" "${PYENV_ROOT}/plugins/pyenv-virtualenv"
-conditional_mv "$TMP_DIR/pyenv-which-ext"  "${PYENV_ROOT}/plugins/pyenv-which-ext"
 
 rm -rf $TMP_DIR
 


### PR DESCRIPTION
because it is now part of pyenv core and the repo is archived, see https://github.com/pyenv/pyenv-which-ext