### PR TITLE
Handle the case when HOME is not set in cloud-init

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set -eu
-[ -n "$PYENV_DEBUG" ] && set -x
+[ -n "${PYENV_DEBUG:-}" ] && set -x
 
-if [ -z "$PYENV_ROOT" ]; then
+if [ -z "${PYENV_ROOT:-}" ]; then
   export PYENV_ROOT="${HOME}/.pyenv"
 fi
 
@@ -38,7 +38,7 @@ if ! command -v git 1>/dev/null 2>&1; then
 fi
 
 # Check ssh authentication if USE_SSH is present
-if [ -n "${USE_SSH}" ]; then
+if [ -n "${USE_SSH:-}" ]; then
   if ! command -v ssh 1>/dev/null 2>&1; then
     echo "pyenv: configuration USE_SSH found but ssh is not installed, can't continue." >&2
     exit 1
@@ -60,7 +60,7 @@ if [ -n "${USE_SSH}" ]; then
   fi
 fi
 
-if [ -n "${USE_SSH}" ]; then
+if [ -n "${USE_SSH:-}" ]; then
   GITHUB="git@github.com:"
 else
   GITHUB="https://github.com/"

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
 
-# Ensure $HOME is set.
-if [ -z ${HOME+x} ]; then
-  printf "%s\n" \
-    "Error: \$HOME must be set." \
-    "It is unset when running in a non-login shell (such as in cloud-init)," \
-    "so you may have to set it manually (typically to \"/root\")." \
-    >&2
-  exit 1
-fi
-
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
 if [ -z "$PYENV_ROOT" ]; then
+  if [ -z "$HOME" ]; then
+    printf "$0: %s\n" \
+      "Either \$PYENV_ROOT or \$HOME must be set to determine the install location." \
+      >&2
+    exit 1
+  fi
   export PYENV_ROOT="${HOME}/.pyenv"
 fi
 

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 
-set -eu
-[ -n "${PYENV_DEBUG:-}" ] && set -x
+# Ensure $HOME is set.
+if [ -z ${HOME+x} ]; then
+  printf "%s\n" \
+    "Error: \$HOME must be set." \
+    "It is unset when running in a non-login shell (such as in cloud-init)," \
+    "so you may have to set it manually (typically to \"/root\")." \
+    >&2
+  exit 1
+fi
 
-if [ -z "${PYENV_ROOT:-}" ]; then
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+if [ -z "$PYENV_ROOT" ]; then
   export PYENV_ROOT="${HOME}/.pyenv"
 fi
 
@@ -38,7 +48,7 @@ if ! command -v git 1>/dev/null 2>&1; then
 fi
 
 # Check ssh authentication if USE_SSH is present
-if [ -n "${USE_SSH:-}" ]; then
+if [ -n "${USE_SSH}" ]; then
   if ! command -v ssh 1>/dev/null 2>&1; then
     echo "pyenv: configuration USE_SSH found but ssh is not installed, can't continue." >&2
     exit 1
@@ -60,7 +70,7 @@ if [ -n "${USE_SSH:-}" ]; then
   fi
 fi
 
-if [ -n "${USE_SSH:-}" ]; then
+if [ -n "${USE_SSH}" ]; then
   GITHUB="git@github.com:"
 else
   GITHUB="https://github.com/"
@@ -68,7 +78,6 @@ fi
 
 checkout "${GITHUB}pyenv/pyenv.git"            "${PYENV_ROOT}"                           "${PYENV_GIT_TAG:-master}"
 checkout "${GITHUB}pyenv/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"      "master"
-checkout "${GITHUB}pyenv/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"   "master"
 checkout "${GITHUB}pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-update"      "master"
 checkout "${GITHUB}pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"  "master"
 

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 [ -n "$PYENV_DEBUG" ] && set -x
 
 if [ -z "$PYENV_ROOT" ]; then

--- a/bin/pyenv-offline-installer
+++ b/bin/pyenv-offline-installer
@@ -4,6 +4,12 @@ set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
 if [ -z "$PYENV_ROOT" ]; then
+  if [ -z "$HOME" ]; then
+    printf "$0: %s\n" \
+      "Either \$PYENV_ROOT or \$HOME must be set to determine the install location." \
+      >&2
+    exit 1
+  fi
   PYENV_ROOT="${HOME}/.pyenv"
 fi
 


### PR DESCRIPTION
I'm installing pyenv in a cloud-init config file, which runs in a context that has no `$HOME` env variable.

It seems pyenv installation relies on this value, and if it is not set, fails silently (installs `.pyenv` directory into `/` the root directory).