### PR TITLE
Fix issue in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ If you need, ``export USE_SSH`` to use ``git@github.com``(SSH pseudo-URL) instea
 
 Update:
 ~~~~
+
 .. code:: bash
 
     pyenv update


### PR DESCRIPTION
Fix issue found in README: because of a missing newline character, the code block in the update section is not rendered correctly.


Before the fix, it looks like:

Update: ~~~~ .. code:: bash

>    pyenv update


With the fix, now the block is correctly rendered:
Update:~~~~
```bash
pyenv update
```