### PR TITLE
Fix core.autocrlf in pyenv-installer

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -35,7 +35,7 @@ failed_checkout() {
 }
 
 checkout() {
-  [ -d "$2" ] || git -c advice.detachedHead=0 clone --branch "$3" --depth 1 "$1" "$2" || failed_checkout "$1"
+  [ -d "$2" ] || git -c advice.detachedHead=0 -c core.autocrlf=false clone --branch "$3" --depth 1 "$1" "$2" || failed_checkout "$1"
 }
 
 if ! command -v git 1>/dev/null 2>&1; then


### PR DESCRIPTION
This PR updates the git clone command to include -c core.autocrlf=false, preventing Git from automatically converting line endings during cloning (which causes problems on certain git configurations, see https://github.com/pyenv/pyenv-installer/issues/116 and https://github.com/pyenv/pyenv-installer/issues/100). This avoids asking users to modify their global Git configuration (which can have unexpected side effects) and having to investigate why pyenv isn't working after installation.